### PR TITLE
Fix log function prefix handling

### DIFF
--- a/mylib/lib.py
+++ b/mylib/lib.py
@@ -8,9 +8,11 @@ def summary_statistics(df, x):
 
 
 def log_func(df, x):
-    if x[0:3] == "log" or x[0:3] == "Log":
+    """Create a log transformed column if a prefix is detected."""
+    lower = x.lower()
+    if lower.startswith("log"):
         df[x] = np.log(df[x[4:]])
-    if x[0:2] == "ln" or x[0:2] == "ln":
+    elif lower.startswith("ln"):
         df[x] = np.log(df[x[3:]])
     return df
 

--- a/test_lib.py
+++ b/test_lib.py
@@ -43,6 +43,14 @@ def test_log_func():
     assert (df[y_log] == np.log(df[y_log[4:]])).any()
 
 
+def test_log_func_ln():
+    """Ensure ln prefix is also handled correctly."""
+    y_ln = "ln y"
+    df = pd.read_csv(file)
+    df = log_func(df, y_ln)
+    assert np.allclose(df[y_ln], np.log(df[y_ln[3:]]))
+
+
 def test_table_format():
     """Testing that .md formatting is running"""
     assert (


### PR DESCRIPTION
## Summary
- improve `log_func` prefix detection logic
- test ln-prefixed log calls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68895e673ed883299bfd00bf931f66d5